### PR TITLE
Bump node version from 12 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,5 @@ inputs:
     required: true
     default: 'coverity-results.sarif'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Hello! First of all, thank you for creating this. It is very nice! 
I noticed while using it however that Node16 actions are being deprecated, so I decided to see what would happen with an upgrade to Node20. Although my usage does not cover all use cases, the CI/CD run passed succesfully and looked normal. 
As [Github has deprecated Node12 actions](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/) and [is deprecating Node16 actions](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), I would suggest moving this to Node20!